### PR TITLE
V1

### DIFF
--- a/src/DataTable.php
+++ b/src/DataTable.php
@@ -14,7 +14,7 @@ class DataTable
     protected $columns;
     protected $allowedColumns = [];
     protected $rowFormatters = [];
-    protected $escapedColumns = [];
+    protected $escapedColumns = ['*'];
     protected $rawColumns = [];
 
     public function __construct($params, $class, $query = null)

--- a/tests/DataTableTest.php
+++ b/tests/DataTableTest.php
@@ -223,6 +223,7 @@ class DataTableTest extends BaseTestCase
 
         $dt = new \SynergiTech\DataTables\DataTable($request, TestModel::class);
         $dt->setAllowedColumns(['test']);
+        $dt->setEscapedColumns([]);
 
         $mock = $this->getMockBuilder('stdClass')
             ->setMethods(['myCallBack'])
@@ -251,6 +252,7 @@ class DataTableTest extends BaseTestCase
 
         $dt = new \SynergiTech\DataTables\DataTable($request, TestModel::class);
         $dt->setAllowedColumns(['one.name', 'one.two.name', 'one.property.does.not.exist']);
+        $dt->setEscapedColumns([]);
 
         $response = $dt->getResponse();
 


### PR DESCRIPTION
We have decided that output encoding should be handled as part of this library.
We will set `escapedColumns` to `[*]` by default.

It's up to the developer to instruct the library about which columns should be raw.

As this is a breaking change, it will be the only change for V1.